### PR TITLE
Fix `canonize` function and enhance index semantics

### DIFF
--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -114,14 +114,14 @@ end
 
 leftsite(tn::Chain, site::Site) = leftsite(boundary(tn), tn, site)
 function leftsite(::Open, tn::Chain, site::Site)
-    (site.id > length(sites(tn)) || site.id <= 1) && throw(ArgumentError("Invalid site $site"))
+    site.id ∉ range(2, length(sites(tn))) && throw(ArgumentError("Invalid site $site"))
     Site(site.id - 1)
 end
 leftsite(::Periodic, tn::Chain, site::Site) = Site(mod1(site.id - 1, length(sites(tn))))
 
 rightsite(tn::Chain, site::Site) = rightsite(boundary(tn), tn, site)
 function rightsite(::Open, tn::Chain, site::Site)
-    (site.id > length(sites(tn))-1 || site.id < 1) && throw(ArgumentError("Invalid site $site"))
+    site.id ∉ range(1, length(sites(tn))-1) && throw(ArgumentError("Invalid site $site"))
     Site(site.id + 1)
 end
 rightsite(::Periodic, tn::Chain, site::Site) = Site(mod1(site.id + 1, length(sites(tn))))

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -112,11 +112,19 @@ function Chain(::Operator, boundary::Open, arrays::Vector{<:AbstractArray})
     Chain(Quantum(TensorNetwork(_tensors), sitemap), boundary)
 end
 
-rightsite(tn::Chain, site::Site) = rightsite(boundary(tn), tn, site)
-rightsite(::Union{Open, Periodic}, tn::Chain, site::Site) = Site(site.id + 1)
-
 leftsite(tn::Chain, site::Site) = leftsite(boundary(tn), tn, site)
-leftsite(::Union{Open, Periodic}, tn::Chain, site::Site) = Site(site.id - 1)
+function leftsite(::Open, tn::Chain, site::Site)
+    (site.id > length(sites(tn)) || site.id <= 1) && throw(ArgumentError("Invalid site $site"))
+    Site(site.id - 1)
+end
+leftsite(::Periodic, tn::Chain, site::Site) = Site(mod1(site.id - 1, length(sites(tn))))
+
+rightsite(tn::Chain, site::Site) = rightsite(boundary(tn), tn, site)
+function rightsite(::Open, tn::Chain, site::Site)
+    (site.id > length(sites(tn))-1 || site.id < 1) && throw(ArgumentError("Invalid site $site"))
+    Site(site.id + 1)
+end
+rightsite(::Periodic, tn::Chain, site::Site) = Site(mod1(site.id + 1, length(sites(tn))))
 
 leftindex(tn::Chain, site::Site) = leftindex(boundary(tn), tn, site)
 function leftindex(::Union{Open, Periodic}, tn::Chain, site::Site)

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -112,15 +112,19 @@ function Chain(::Operator, boundary::Open, arrays::Vector{<:AbstractArray})
     Chain(Quantum(TensorNetwork(_tensors), sitemap), boundary)
 end
 
+rightsite(tn::Chain, site::Site) = rightsite(boundary(tn), tn, site)
+rightsite(::Open, tn::Chain, site::Site) = Site(site.id + 1)
+
+leftsite(tn::Chain, site::Site) = leftsite(boundary(tn), tn, site)
+leftsite(::Open, tn::Chain, site::Site) = Site(site.id - 1)
+
 leftindex(tn::Chain, site::Site) = leftindex(boundary(tn), tn, site)
 leftindex(::Periodic, tn::Chain, site::Site) = (select(tn, :tensor, site)|>inds)[end-1]
 function leftindex(::Open, tn::Chain, site::Site)
     if site == site"1"
         nothing
-    elseif site == Site(nsites(tn)) # TODO review
-        (select(tn, :tensor, site)|>inds)[end]
     else
-        (select(tn, :tensor, site)|>inds)[end-1]
+        (select(tn, :tensor, site)|>inds) ∩ (select(tn, :tensor, leftsite(tn, site))|>inds) |> only
     end
 end
 
@@ -130,7 +134,7 @@ function rightindex(::Open, tn::Chain, site::Site)
     if site == Site(nsites(tn)) # TODO review
         nothing
     else
-        (select(tn, :tensor, site)|>inds)[end]
+        (select(tn, :tensor, site)|>inds) ∩ (select(tn, :tensor, rightsite(tn, site))|>inds) |> only
     end
 end
 

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -113,14 +113,13 @@ function Chain(::Operator, boundary::Open, arrays::Vector{<:AbstractArray})
 end
 
 rightsite(tn::Chain, site::Site) = rightsite(boundary(tn), tn, site)
-rightsite(::Open, tn::Chain, site::Site) = Site(site.id + 1)
+rightsite(::Union{Open, Periodic}, tn::Chain, site::Site) = Site(site.id + 1)
 
 leftsite(tn::Chain, site::Site) = leftsite(boundary(tn), tn, site)
-leftsite(::Open, tn::Chain, site::Site) = Site(site.id - 1)
+leftsite(::Union{Open, Periodic}, tn::Chain, site::Site) = Site(site.id - 1)
 
 leftindex(tn::Chain, site::Site) = leftindex(boundary(tn), tn, site)
-leftindex(::Periodic, tn::Chain, site::Site) = (select(tn, :tensor, site)|>inds)[end-1]
-function leftindex(::Open, tn::Chain, site::Site)
+function leftindex(::Union{Open, Periodic}, tn::Chain, site::Site)
     if site == site"1"
         nothing
     else
@@ -129,8 +128,7 @@ function leftindex(::Open, tn::Chain, site::Site)
 end
 
 rightindex(tn::Chain, site::Site) = rightindex(boundary(tn), tn, site)
-rightindex(::Periodic, tn::Chain, site::Site) = (select(tn, :tensor, site)|>inds)[end]
-function rightindex(::Open, tn::Chain, site::Site)
+function rightindex(::Union{Open, Periodic}, tn::Chain, site::Site)
     if site == Site(nsites(tn)) # TODO review
         nothing
     else

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -142,7 +142,7 @@ canonize(tn::Chain, args...; kwargs...) = canonize!(deepcopy(tn), args...; kwarg
 canonize!(tn::Chain, args...; kwargs...) = canonize!(boundary(tn), tn, args...; kwargs...)
 
 # NOTE: in mode == :svd the spectral weights are stored in a vector connected to the now virtual hyperindex!
-function canonize!(::Open, tn::Chain, site::Site; direction::Symbol, mode::Symbol = :qr)
+function canonize!(::Open, tn::Chain, site::Site; direction::Symbol, mode = :qr)
     left_inds = Symbol[]
     right_inds = Symbol[]
 

--- a/src/Qrochet.jl
+++ b/src/Qrochet.jl
@@ -17,7 +17,7 @@ export Product
 include("Ansatz/Chain.jl")
 export Chain
 export MPS, pMPS, MPO, pMPO
-export leftindex, rightindex, canonize!
+export leftindex, rightindex, canonize, canonize!
 
 # reexports from Tenet
 using Tenet

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -26,4 +26,43 @@
     @test noutputs(qtn) == 3
     @test issetequal(sites(qtn), [site"1", site"2", site"3", site"1'", site"2'", site"3'"])
     @test boundary(qtn) == Open()
+
+    @testset "canonize" begin
+        function is_left_canonical(qtn, s::Site)
+           label_r = rightindex(qtn, s)
+           A = select(qtn, :tensor, s)
+           try
+               contracted = contract(A, replace(conj(A), label_r => :new_ind_name))
+               return isapprox(contracted, Matrix{Float64}(I, size(A, label_r), size(A, label_r)), atol=1e-12)
+           catch
+               return false
+           end
+       end
+
+        function is_right_canonical(qtn, s::Site)
+           label_l = leftindex(qtn, s)
+           A = select(qtn, :tensor, s)
+           try
+               contracted = contract(A, replace(conj(A), label_l => :new_ind_name))
+               return isapprox(contracted, Matrix{Float64}(I, size(A, label_l), size(A, label_l)), atol=1e-12)
+           catch
+               return false
+           end
+       end
+
+        qtn = Chain(State(), Open(), [rand(4, 4), rand(4, 4, 4), rand(4, 4)])
+
+        @test_throws ArgumentError canonize!(qtn, Site(1); direction=:right)
+        @test_throws ArgumentError canonize!(qtn, Site(3); direction=:left)
+
+        for mode in [:qr, :svd]
+            for i in 1:length(sites(qtn))
+                if i != 1
+                    @test is_right_canonical(canonize(qtn, Site(i); direction=:right, mode=mode), Site(i))
+                elseif i != length(sites(qtn))
+                    @test is_left_canonical(canonize(qtn, Site(i); direction=:left, mode=mode), Site(i))
+                end
+            end
+        end
+    end
 end

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -28,6 +28,8 @@
     @test boundary(qtn) == Open()
 
     @testset "canonize" begin
+        using Tenet
+
         function is_left_canonical(qtn, s::Site)
            label_r = rightindex(qtn, s)
            A = select(qtn, :tensor, s)
@@ -58,11 +60,18 @@
         for mode in [:qr, :svd]
             for i in 1:length(sites(qtn))
                 if i != 1
-                    @test is_right_canonical(canonize(qtn, Site(i); direction=:right, mode=mode), Site(i))
+                    canonized = canonize(qtn, Site(i); direction=:right, mode=mode)
+                    @test is_right_canonical(canonized, Site(i))
+                    @test isapprox(contract(transform(TensorNetwork(canonized), Tenet.HyperindConverter())), contract(TensorNetwork(qtn)))
                 elseif i != length(sites(qtn))
-                    @test is_left_canonical(canonize(qtn, Site(i); direction=:left, mode=mode), Site(i))
+                    canonized = canonize(qtn, Site(i); direction=:left, mode=mode)
+                    @test is_left_canonical(canonized, Site(i))
+                    @test isapprox(contract(transform(TensorNetwork(canonized), Tenet.HyperindConverter())), contract(TensorNetwork(qtn)))
                 end
             end
         end
+
+        # Ensure that svd creates a new tensor
+        @test length(tensors(canonize(qtn, Site(2); direction=:right, mode=:svd))) == 4
     end
 end

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -27,6 +27,30 @@
     @test issetequal(sites(qtn), [site"1", site"2", site"3", site"1'", site"2'", site"3'"])
     @test boundary(qtn) == Open()
 
+    @testset "Site" begin
+        using Qrochet: leftsite, rightsite
+        qtn = Chain(State(), Periodic(), [rand(2, 4, 4) for _ in 1:3])
+
+        @test leftsite(qtn, Site(1)) == Site(3)
+        @test leftsite(qtn, Site(2)) == Site(1)
+        @test leftsite(qtn, Site(3)) == Site(2)
+
+        @test rightsite(qtn, Site(1)) == Site(2)
+        @test rightsite(qtn, Site(2)) == Site(3)
+        @test rightsite(qtn, Site(3)) == Site(1)
+
+        qtn = Chain(State(), Open(), [rand(2, 2), rand(2, 2, 2), rand(2, 2)])
+
+        @test_throws ArgumentError leftsite(qtn, Site(1))
+        @test_throws ArgumentError rightsite(qtn, Site(3))
+
+        @test leftsite(qtn, Site(2)) == Site(1)
+        @test leftsite(qtn, Site(3)) == Site(2)
+
+        @test rightsite(qtn, Site(2)) == Site(3)
+        @test rightsite(qtn, Site(1)) == Site(2)
+    end
+
     @testset "canonize" begin
         using Tenet
 


### PR DESCRIPTION
### Summary
This PR fixes the `canonize` function, enabling it to correctly canonize a desired `Tensor` within a `Site` of a `Chain`. We have enhanced this function to allow users to choose the `mode` (`:qr` or `:svd`) in which the canonization is applied. By default, the `:qr` option is selected, preserving the total number of tensors in the `TensorNetwork`. The `:svd` mode, on the other hand, introduces a new tensor which is connected by a hyperindex to the bond between sites, and it contains the Schmidt values. Additionally, we have created a comprehensive test set to ensure the function's reliability and performance.

Furthermore, we have refactored the logic inside `leftindex` and `rightindex`. Now, these indices are determined by the intersection of the indices with those of the adjacent tensor in the `Chain`, rather than relying on the order of `inds` in the tensors. This enhancement is expected to make our library more robust and error-resistant, as changes in the tensor order will no longer have unintended side effects.

### Example
Here we show how we create a `Chain` and we canonize the middle tensor:
```julia
julia> function is_left_canonical(qtn, s::Site)
          label_r = rightindex(qtn, s)
          A = select(qtn, :tensor, s)
          try
              contracted = contract(A, replace(conj(A), label_r => :new_ind_name))
              return isapprox(contracted, Matrix{Float64}(I, size(A, label_r), size(A, label_r)), atol=1e-12)
          catch
              return false
          end
       end
is_left_canonical (generic function with 1 method)

julia> function is_right_canonical(qtn, s::Site)
          label_l = leftindex(qtn, s)
          A = select(qtn, :tensor, s)
          try
              contracted = contract(A, replace(conj(A), label_l => :new_ind_name))
              return isapprox(contracted, Matrix{Float64}(I, size(A, label_l), size(A, label_l)), atol=1e-12)
          catch
              return false
          end
       end
is_right_canonical (generic function with 1 method)

julia> qtn  = Chain(State(), Open(), [rand(4, 4), rand(4, 4, 4), rand(4, 4)])
MPS (inputs=0, outputs=3)

julia> canonized = canonize(qtn, Site(2); direction=:left, mode=:qr) # We left-canonize the tensor on the second site
MPS (inputs=0, outputs=3)

julia> is_left_canonical(canonized, Site(2))
true

julia> canonized = canonize(qtn, Site(2); direction=:right, mode=:svd) # We right-canonize the tensor on the second site using svd
MPS (inputs=0, outputs=3)

julia> length(tensors(canonized))
4

julia> contract(transform(TensorNetwork(canonized), HyperindConverter())) |> inds^C

julia> isapprox(contract(transform(TensorNetwork(canonized), Tenet.HyperindConverter())), contract(TensorNetwork(qtn)))
true
```