### PR TITLE
Add `rand` initialization for `Chain`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,8 @@ version = "0.1.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Muscle = "21fe5c4b-a943-414d-bf3e-516f24900631"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Tenet = "85d41934-b9cd-44e1-8730-56d86f15f3ec"
 ValSplit = "0625e100-946b-11ec-09cd-6328dd093154"
 

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -1,5 +1,6 @@
 using Tenet
 using ValSplit
+using LinearAlgebra
 
 """
     Ansatz
@@ -56,4 +57,11 @@ MissingSchmidtCoefficientsException(bond::Vector{Site}) = MissingSchmidtCoeffici
 
 function Base.showerror(io::IO, e::MissingSchmidtCoefficientsException)
     print(io, "Can't access the spectrum on bond $(e.bond)")
+end
+
+function LinearAlgebra.norm(ψ::Ansatz, p::Real = 2; kwargs...)
+    p != 2 && throw(ArgumentError("p=$p is not implemented yet"))
+
+    # TODO: Replace with contract(hcat(ψ, ψ')...) when implemented
+    return contract(merge(TensorNetwork(ψ), TensorNetwork(ψ')); kwargs...) |> only |> sqrt |> abs
 end

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -148,17 +148,22 @@ end
 
 Base.adjoint(chain::Chain) = Chain(adjoint(Quantum(chain)), boundary(chain))
 
-struct ChainSampler{B<:Qrochet.Boundary, S<:Qrochet.Socket, NT<:NamedTuple} <: Random.Sampler{Chain}
+struct ChainSampler{B<:Qrochet.Boundary,S<:Qrochet.Socket,NT<:NamedTuple} <: Random.Sampler{Chain}
     parameters::NT
 
-    ChainSampler{B, S}(; kwargs...) where {B, S} = new{B, S,typeof(values(kwargs))}(values(kwargs))
+    ChainSampler{B,S}(; kwargs...) where {B,S} = new{B,S,typeof(values(kwargs))}(values(kwargs))
 end
 
 Base.rand(A::Type{<:Chain}, B::Type{<:Qrochet.Boundary}, S::Type{<:Qrochet.Socket}; kwargs...) =
     rand(Random.default_rng(), A, B, S; kwargs...)
 
-Base.rand(rng::AbstractRNG, ::Type{A}, ::Type{B}, ::Type{S}; kwargs...) where {A<:Chain, B<:Qrochet.Boundary, S<:Qrochet.Socket} =
-    rand(rng, ChainSampler{B, S}(; kwargs...), B, S)
+Base.rand(
+    rng::AbstractRNG,
+    ::Type{A},
+    ::Type{B},
+    ::Type{S};
+    kwargs...,
+) where {A<:Chain,B<:Qrochet.Boundary,S<:Qrochet.Socket} = rand(rng, ChainSampler{B,S}(; kwargs...), B, S)
 
 function Base.rand(rng::Random.AbstractRNG, sampler::ChainSampler, ::Type{Open}, ::Type{State})
     n = sampler.parameters.n

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -146,28 +146,11 @@ function rightindex(::Union{Open,Periodic}, tn::Chain, site::Site)
     end
 end
 
-"""
-    adjoint(tn::TensorNetwork{<:Quantum})
-
-Return the adjoint [`TensorNetwork`](@ref).
-
-# Implementation details
-
-The tensors are not transposed, just `conj!` is applied to them.
-"""
-function Base.adjoint(qtn::Chain)
-    qtn = deepcopy(qtn)
-
-    foreach(conj!, tensors(qtn))
-
-    return qtn
-end
-
 function LinearAlgebra.norm(ψ::Chain, p::Real = 2; kwargs...)
     p != 2 && throw(ArgumentError("p=$p is not implemented yet"))
 
-    # TODO: Replace with hcat when implemented
-    return contract(tensors(TensorNetwork(ψ))..., tensors(TensorNetwork(ψ'))...; kwargs...) |> only |> sqrt |> abs
+    # TODO: Replace with contract(hcat(ψ, ψ')...) when implemented
+    return contract(contract(TensorNetwork(ψ)), contract(TensorNetwork(ψ')); kwargs...) |> only |> sqrt |> abs
 end
 
 struct ChainSampler{B<:Qrochet.Boundary, S<:Qrochet.Socket, NT<:NamedTuple} <: Random.Sampler{Chain}

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -146,30 +146,7 @@ function rightindex(::Union{Open,Periodic}, tn::Chain, site::Site)
     end
 end
 
-function Base.adjoint(chain::Chain)
-    chain = deepcopy(chain)
-    # TODO: Make this work for `Chain`s with singular values between sites
-    length(tensors(chain)) != length(sites(chain)) && throw(ArgumentError("Cannot adjoint a Chain with singular values"))
-    q = chain.super
-
-    # Update the virtual indices
-    for site in sites(chain)
-        left = leftindex(chain, site)
-        left !== nothing && replace!(q.tn, left => Symbol(string(left, "'")))
-    end
-    right = rightindex(chain, sites(chain)[end])
-    right !== nothing && replace!(q.tn, right => Symbol(string(right, "'")))
-
-    foreach(conj!, tensors(q.tn))
-    return chain
-end
-
-function LinearAlgebra.norm(ψ::Chain, p::Real = 2; kwargs...)
-    p != 2 && throw(ArgumentError("p=$p is not implemented yet"))
-
-    # TODO: Replace with contract(hcat(ψ, ψ')...) when implemented
-    return contract(merge(TensorNetwork(ψ), TensorNetwork(ψ')); kwargs...) |> only |> sqrt |> abs
-end
+Base.adjoint(chain::Chain) = Chain(adjoint(Quantum(chain)), boundary(chain))
 
 struct ChainSampler{B<:Qrochet.Boundary, S<:Qrochet.Socket, NT<:NamedTuple} <: Random.Sampler{Chain}
     parameters::NT

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -146,11 +146,29 @@ function rightindex(::Union{Open,Periodic}, tn::Chain, site::Site)
     end
 end
 
+function Base.adjoint(chain::Chain)
+    chain = deepcopy(chain)
+    # TODO: Make this work for `Chain`s with singular values between sites
+    length(tensors(chain)) != length(sites(chain)) && throw(ArgumentError("Cannot adjoint a Chain with singular values"))
+    q = chain.super
+
+    # Update the virtual indices
+    for site in sites(chain)
+        left = leftindex(chain, site)
+        left !== nothing && replace!(q.tn, left => Symbol(string(left, "'")))
+    end
+    right = rightindex(chain, sites(chain)[end])
+    right !== nothing && replace!(q.tn, right => Symbol(string(right, "'")))
+
+    foreach(conj!, tensors(q.tn))
+    return chain
+end
+
 function LinearAlgebra.norm(ψ::Chain, p::Real = 2; kwargs...)
     p != 2 && throw(ArgumentError("p=$p is not implemented yet"))
 
     # TODO: Replace with contract(hcat(ψ, ψ')...) when implemented
-    return contract(contract(TensorNetwork(ψ)), contract(TensorNetwork(ψ')); kwargs...) |> only |> sqrt |> abs
+    return contract(merge(TensorNetwork(ψ), TensorNetwork(ψ')); kwargs...) |> only |> sqrt |> abs
 end
 
 struct ChainSampler{B<:Qrochet.Boundary, S<:Qrochet.Socket, NT<:NamedTuple} <: Random.Sampler{Chain}

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -217,6 +217,47 @@ function Base.rand(rng::Random.AbstractRNG, sampler::ChainSampler, ::Type{Open},
     Chain(State(), Open(), arrays)
 end
 
+# TODO let choose the orthogonality center
+# TODO different input/output physical dims
+function Base.rand(rng::Random.AbstractRNG, sampler::ChainSampler, ::Type{Open}, ::Type{Operator})
+    n = sampler.parameters.n
+    χ = sampler.parameters.χ
+    p = get(sampler.parameters, :p, 2)
+    T = get(sampler.parameters, :eltype, Float64)
+
+    ip = op = p
+
+    arrays::Vector{AbstractArray{T,N} where {N}} = map(1:n) do i
+        χl, χr = let after_mid = i > n ÷ 2, i = (n + 1 - abs(2i - n - 1)) ÷ 2
+            χl = min(χ, ip^(i - 1) * op^(i - 1))
+            χr = min(χ, ip^i * op^i)
+
+            # swap bond dims after mid and handle midpoint for odd-length MPS
+            (isodd(n) && i == n ÷ 2 + 1) ? (χl, χl) : (after_mid ? (χr, χl) : (χl, χr))
+        end
+
+        shape = if i == 1
+            (χr, ip, op)
+        elseif i == n
+            (χl, ip, op)
+        else
+            (χl, χr, ip, op)
+        end
+
+        # orthogonalize by Gram-Schmidt algorithm
+        A = gramschmidt!(rand(rng, T, shape[1], prod(shape[2:end])))
+        A = reshape(A, shape)
+
+        (i == 1 || i == n) ? permutedims(A, (2, 3, 1)) : permutedims(A, (3, 4, 1, 2))
+    end
+
+    # normalize
+    ζ = min(χ, ip * op)
+    arrays[1] ./= sqrt(ζ)
+
+    Chain(Operator(), Open(), arrays)
+end
+
 canonize_site(tn::Chain, args...; kwargs...) = canonize_site!(deepcopy(tn), args...; kwargs...)
 canonize_site!(tn::Chain, args...; kwargs...) = canonize_site!(boundary(tn), tn, args...; kwargs...)
 

--- a/src/Quantum.jl
+++ b/src/Quantum.jl
@@ -72,12 +72,12 @@ end
 # TODO (@mofeing) Return `copy`?
 Tenet.TensorNetwork(q::Quantum) = q.tn
 
-function Base.adjoint(q::Quantum)
-    sites = Iterators.map(q.sites) do (site, index)
+function Base.adjoint(qtn::Quantum)
+    sites = Iterators.map(qtn.sites) do (site, index)
         site' => index
     end |> Dict{Site,Symbol}
 
-    tn = conj(q.tn)
+    tn = conj(TensorNetwork(qtn))
 
     # rename inner indices
     physical_inds = values(sites)

--- a/src/Quantum.jl
+++ b/src/Quantum.jl
@@ -76,7 +76,17 @@ function Base.adjoint(q::Quantum)
     sites = Iterators.map(q.sites) do (site, index)
         site' => index
     end |> Dict{Site,Symbol}
-    Quantum(conj(q.tn), sites)
+
+    tn = conj(q.tn)
+
+    # rename inner indices
+    physical_inds = values(sites)
+    virtual_inds = setdiff(inds(tn), physical_inds)
+    replace!(tn, map(virtual_inds) do i
+        i => Symbol(i, "'")
+    end...)
+
+    Quantum(tn, sites)
 end
 
 ninputs(q::Quantum) = count(isdual, keys(q.sites))

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -72,21 +72,32 @@
     @testset "rand" begin
         using LinearAlgebra: norm
 
-        qtn = rand(Chain, Open, State; n = 5, p = 2, χ = 20)
+        chi = 10
+        qtn = rand(Chain, Open, State; n = 6, p = 2, χ = chi)
         @test socket(qtn) == State()
         @test ninputs(qtn) == 0
-        @test noutputs(qtn) == 5
-        @test issetequal(sites(qtn), [site"1", site"2", site"3", site"4", site"5"])
+        @test noutputs(qtn) == 6
+        @test issetequal(sites(qtn), [site"1", site"2", site"3", site"4", site"5", site"6"])
         @test boundary(qtn) == Open()
         @test isapprox(norm(qtn), 1.0)
 
-        qtn = rand(Chain, Open, Operator; n = 5, p = 2, χ = 20)
+        inds_ = reduce(vcat, [inds(tensor) for tensor in tensors(mps)])
+        unique_inds = filter(index -> count(x -> x == index, inds_) == 1, inds_)
+        @test !any(index -> size(TensorNetwork(mps), index) > chi, unique_inds)
+
+        qtn = rand(Chain, Open, Operator; n = 6, p = 2, χ = chi)
         @test socket(qtn) == Operator()
-        @test ninputs(qtn) == 5
-        @test noutputs(qtn) == 5
-        @test issetequal(sites(qtn), [site"1", site"2", site"3", site"4", site"5", site"1'", site"2'", site"3'", site"4'", site"5'"])
+        @test ninputs(qtn) == 6
+        @test noutputs(qtn) == 6
+        @test issetequal(sites(qtn),
+            [site"1", site"2", site"3", site"4", site"5", site"6",
+            site"1'", site"2'", site"3'", site"4'", site"5'", site"6'"])
         @test boundary(qtn) == Open()
         @test isapprox(norm(qtn), 1.0)
+
+        inds_ = reduce(vcat, [inds(tensor) for tensor in tensors(mpo)])
+        unique_inds = filter(index -> count(x -> x == index, inds_) == 1, inds_)
+        @test !any(index -> size(TensorNetwork(mpo), index) > chi, unique_inds)
     end
 
     @testset "Canonization" begin

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -81,9 +81,9 @@
         @test boundary(qtn) == Open()
         @test isapprox(norm(qtn), 1.0)
 
-        inds_ = reduce(vcat, [inds(tensor) for tensor in tensors(mps)])
+        inds_ = reduce(vcat, [inds(tensor) for tensor in tensors(qtn)])
         unique_inds = filter(index -> count(x -> x == index, inds_) == 1, inds_)
-        @test !any(index -> size(TensorNetwork(mps), index) > chi, unique_inds)
+        @test !any(index -> size(TensorNetwork(qtn), index) > chi, unique_inds)
 
         qtn = rand(Chain, Open, Operator; n = 6, p = 2, χ = chi)
         @test socket(qtn) == Operator()
@@ -95,9 +95,9 @@
         @test boundary(qtn) == Open()
         @test isapprox(norm(qtn), 1.0)
 
-        inds_ = reduce(vcat, [inds(tensor) for tensor in tensors(mpo)])
+        inds_ = reduce(vcat, [inds(tensor) for tensor in tensors(qtn)])
         unique_inds = filter(index -> count(x -> x == index, inds_) == 1, inds_)
-        @test !any(index -> size(TensorNetwork(mpo), index) > chi, unique_inds)
+        @test !any(index -> size(TensorNetwork(qtn), index) > chi, unique_inds)
     end
 
     @testset "Canonization" begin

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -83,7 +83,7 @@
             @test issetequal(sites(qtn), map(Site, 1:n))
             @test boundary(qtn) == Open()
             @test isapprox(norm(qtn), 1.0)
-            @test maximum(last, size(tn)) <= χ
+            @test maximum(last, size(TensorNetwork(qtn))) <= χ
         end
 
         @testset "Operator" begin
@@ -97,7 +97,7 @@
             @test issetequal(sites(qtn), vcat(map(Site, 1:n), map(adjoint ∘ Site, 1:n)))
             @test boundary(qtn) == Open()
             @test isapprox(norm(qtn), 1.0)
-            @test maximum(last, size(tn)) <= χ
+            @test maximum(last, size(TensorNetwork(qtn))) <= χ
         end
     end
 

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -72,11 +72,19 @@
     @testset "rand" begin
         using LinearAlgebra: norm
 
-        qtn = rand(Chain, Open, State; n = 5, p = 2, χ=20)
+        qtn = rand(Chain, Open, State; n = 5, p = 2, χ = 20)
         @test socket(qtn) == State()
         @test ninputs(qtn) == 0
         @test noutputs(qtn) == 5
         @test issetequal(sites(qtn), [site"1", site"2", site"3", site"4", site"5"])
+        @test boundary(qtn) == Open()
+        @test isapprox(norm(qtn), 1.0)
+
+        qtn = rand(Chain, Open, Operator; n = 5, p = 2, χ = 20)
+        @test socket(qtn) == Operator()
+        @test ninputs(qtn) == 5
+        @test noutputs(qtn) == 5
+        @test issetequal(sites(qtn), [site"1", site"2", site"3", site"4", site"5", site"1'", site"2'", site"3'", site"4'", site"5'"])
         @test boundary(qtn) == Open()
         @test isapprox(norm(qtn), 1.0)
     end

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -72,32 +72,33 @@
     @testset "rand" begin
         using LinearAlgebra: norm
 
-        chi = 10
-        qtn = rand(Chain, Open, State; n = 6, p = 2, χ = chi)
-        @test socket(qtn) == State()
-        @test ninputs(qtn) == 0
-        @test noutputs(qtn) == 6
-        @test issetequal(sites(qtn), [site"1", site"2", site"3", site"4", site"5", site"6"])
-        @test boundary(qtn) == Open()
-        @test isapprox(norm(qtn), 1.0)
+        @testset "State" begin
+            n = 8
+            χ = 10
 
-        inds_ = reduce(vcat, [inds(tensor) for tensor in tensors(qtn)])
-        unique_inds = filter(index -> count(x -> x == index, inds_) == 1, inds_)
-        @test !any(index -> size(TensorNetwork(qtn), index) > chi, unique_inds)
+            qtn = rand(Chain, Open, State; n, p = 2, χ)
+            @test socket(qtn) == State()
+            @test ninputs(qtn) == 0
+            @test noutputs(qtn) == n
+            @test issetequal(sites(qtn), map(Site, 1:n))
+            @test boundary(qtn) == Open()
+            @test isapprox(norm(qtn), 1.0)
+            @test maximum(last, size(tn)) <= χ
+        end
 
-        qtn = rand(Chain, Open, Operator; n = 6, p = 2, χ = chi)
-        @test socket(qtn) == Operator()
-        @test ninputs(qtn) == 6
-        @test noutputs(qtn) == 6
-        @test issetequal(sites(qtn),
-            [site"1", site"2", site"3", site"4", site"5", site"6",
-            site"1'", site"2'", site"3'", site"4'", site"5'", site"6'"])
-        @test boundary(qtn) == Open()
-        @test isapprox(norm(qtn), 1.0)
+        @testset "Operator" begin
+            n = 8
+            χ = 10
 
-        inds_ = reduce(vcat, [inds(tensor) for tensor in tensors(qtn)])
-        unique_inds = filter(index -> count(x -> x == index, inds_) == 1, inds_)
-        @test !any(index -> size(TensorNetwork(qtn), index) > chi, unique_inds)
+            qtn = rand(Chain, Open, Operator; n, p = 2, χ)
+            @test socket(qtn) == Operator()
+            @test ninputs(qtn) == n
+            @test noutputs(qtn) == n
+            @test issetequal(sites(qtn), vcat(map(Site, 1:n), map(adjoint ∘ Site, 1:n)))
+            @test boundary(qtn) == Open()
+            @test isapprox(norm(qtn), 1.0)
+            @test maximum(last, size(tn)) <= χ
+        end
     end
 
     @testset "Canonization" begin

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -69,6 +69,18 @@
         # @test size(TensorNetwork(truncated), leftindex(truncated, Site(3))) == 1
     end
 
+    @testset "rand" begin
+        using LinearAlgebra: norm
+
+        qtn = rand(Chain, Open, State; n = 5, p = 2, χ=20)
+        @test socket(qtn) == State()
+        @test ninputs(qtn) == 0
+        @test noutputs(qtn) == 5
+        @test issetequal(sites(qtn), [site"1", site"2", site"3", site"4", site"5"])
+        @test boundary(qtn) == Open()
+        @test isapprox(norm(qtn), 1.0)
+    end
+
     @testset "Canonization" begin
         using Tenet
 


### PR DESCRIPTION
### Summary
This PR addresses #12 by adding the `rand` function for `Chain` types. For now, we have implemented it for `Chain(Open, State)` and `Chain(Open, Operator`).

@mofeing, the only thing missing now is the code in [here](https://github.com/bsc-quantic/Tenet.jl/blob/v0.3.0/src/Quantum/MP.jl#L208C1-L220C4). Do you think this is necessary? 