### PR TITLE
Fix `isleftcanonical` and `isrightcanonical` to work for boundary tensors

### DIFF
--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -311,14 +311,15 @@ end
 
 function isleftcanonical(qtn::Chain, site; atol::Real = 1e-12)
     right_ind = rightindex(qtn, site)
+    tensor = select(qtn, :tensor, site)
 
-    # we are at right-most site, which cannot be left-canonical
+    # we are at right-most site, we need to add an extra dummy dimension to the tensor
     if isnothing(right_ind)
-        return false
+        tensor = Tensor(reshape(parent(tensor), size(tensor)..., 1), (inds(tensor)..., :dummy_ind))
+        right_ind = :dummy_ind
     end
 
     # TODO is replace(conj(A)...) copying too much?
-    tensor = select(qtn, :tensor, site)
     contracted = contract(tensor, replace(conj(tensor), right_ind => :new_ind_name))
     n = size(tensor, right_ind)
     identity_matrix = Matrix(I, n, n)

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -329,14 +329,15 @@ end
 
 function isrightcanonical(qtn::Chain, site; atol::Real = 1e-12)
     left_ind = leftindex(qtn, site)
+    tensor = select(qtn, :tensor, site)
 
-    # we are at left-most site, which cannot be right-canonical
+    # we are at left-most site, we need to add an extra dummy dimension to the tensor
     if isnothing(left_ind)
-        return false
+        tensor = Tensor(reshape(parent(tensor), 1, size(tensor)...), (:dummy_ind, inds(tensor)...))
+        left_ind = :dummy_ind
     end
 
     #TODO is replace(conj(A)...) copying too much?
-    tensor = select(qtn, :tensor, site)
     contracted = contract(tensor, replace(conj(tensor), left_ind => :new_ind_name))
     n = size(tensor, left_ind)
     identity_matrix = Matrix(I, n, n)


### PR DESCRIPTION
### Summary
Currently, the `isleftcanonical` (`isrightcanonical`) function does not work for the right(left)-most `Tensor` in a `Chain`. In this PR, we fix this by adding a "dummy" extra dimension to these boundary tensors, in order to be able to check their canonical form.