### PR TITLE
Extend `Tenet.contract` to contract `:between` two `Site`s  

### DIFF
--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -1,7 +1,6 @@
 using Tenet
 using LinearAlgebra
 using Random
-using ValSplit
 using Muscle: gramschmidt!
 
 struct Chain <: Ansatz
@@ -230,7 +229,6 @@ end
 
 Tenet.contract(tn::Chain, query::Symbol, args...; kwargs...) = contract!(copy(tn), Val(query), args...; kwargs...)
 Tenet.contract!(tn::Chain, query::Symbol, args...; kwargs...) = contract!(tn, Val(query), args...; kwargs...)
-@valsplit 2 Tenet.contract!(tn::Chain, query::Symbol, args...; kwargs...) = error("Query ':$query' not defined")
 
 function Tenet.contract!(tn::Chain, ::Val{:between}, site1::Site, site2::Site; direction::Symbol = :left)
     Λᵢ = select(tn, :between, site1, site2)

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -229,7 +229,7 @@ end
 
 Tenet.contract(tn::Chain, query::Symbol, args...; kwargs...) =
     Tenet.contract!(copy(tn)::Chain, query, args...; kwargs...)
-Tenet.contract!(tn::Chain, query::Symbol, args...; kwargs...) =
+@valsplit 2 Tenet.contract!(tn::Chain, query::Symbol, args...; kwargs...) =
     Tenet.contract!(boundary(tn), tn::Chain, Val(query), args...; kwargs...)
 
 function Tenet.contract!(::Open, tn::Chain, ::Val{:between}, site1::Site, site2::Site; direction::Symbol = :left)

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -1,6 +1,7 @@
 using Tenet
 using LinearAlgebra
 using Random
+using ValSplit
 using Muscle: gramschmidt!
 
 struct Chain <: Ansatz
@@ -227,12 +228,10 @@ function Base.rand(rng::Random.AbstractRNG, sampler::ChainSampler, ::Type{Open},
     Chain(Operator(), Open(), arrays)
 end
 
-Tenet.contract(tn::Chain, query::Symbol, args...; kwargs...) =
-    Tenet.contract!(copy(tn)::Chain, query, args...; kwargs...)
-@valsplit 2 Tenet.contract!(tn::Chain, query::Symbol, args...; kwargs...) =
-    Tenet.contract!(boundary(tn), tn::Chain, Val(query), args...; kwargs...)
+@valsplit 2 Tenet.contract(tn::Chain, query::Symbol, site1::Site, site2::Site; direction::Symbol = :left) =
+    Tenet.contract!(copy(tn), Val(query), site1, site2; direction=direction)
 
-function Tenet.contract!(::Open, tn::Chain, ::Val{:between}, site1::Site, site2::Site; direction::Symbol = :left)
+function Tenet.contract!(tn::Chain, ::Val{:between}, site1::Site, site2::Site; direction::Symbol = :left)
     Λᵢ = select(tn, :between, site1, site2)
     Λᵢ === nothing && return tn
 

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -229,6 +229,7 @@ function Base.rand(rng::Random.AbstractRNG, sampler::ChainSampler, ::Type{Open},
 end
 
 Tenet.contract(tn::Chain, query::Symbol, args...; kwargs...) = contract!(copy(tn), Val(query), args...; kwargs...)
+Tenet.contract!(tn::Chain, query::Symbol, args...; kwargs...) = contract!(tn, Val(query), args...; kwargs...)
 @valsplit 2 Tenet.contract!(tn::Chain, query::Symbol, args...; kwargs...) = error("Query ':$query' not defined")
 
 function Tenet.contract!(tn::Chain, ::Val{:between}, site1::Site, site2::Site; direction::Symbol = :left)
@@ -344,6 +345,7 @@ function isleftcanonical(qtn::Chain, site; atol::Real = 1e-12)
 
     # TODO is replace(conj(A)...) copying too much?
     contracted = contract(tensor, replace(conj(tensor), right_ind => :new_ind_name))
+    println("contracted: $contracted")
     n = size(tensor, right_ind)
     identity_matrix = Matrix(I, n, n)
 
@@ -362,6 +364,7 @@ function isrightcanonical(qtn::Chain, site; atol::Real = 1e-12)
 
     #TODO is replace(conj(A)...) copying too much?
     contracted = contract(tensor, replace(conj(tensor), left_ind => :new_ind_name))
+    println("contracted: $contracted")
     n = size(tensor, left_ind)
     identity_matrix = Matrix(I, n, n)
 

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -229,7 +229,7 @@ function Base.rand(rng::Random.AbstractRNG, sampler::ChainSampler, ::Type{Open},
 end
 
 @valsplit 2 Tenet.contract(tn::Chain, query::Symbol, site1::Site, site2::Site; direction::Symbol = :left) =
-    Tenet.contract!(copy(tn), Val(query), site1, site2; direction=direction)
+    Tenet.contract!(copy(tn), Val(query), site1, site2; direction = direction)
 
 function Tenet.contract!(tn::Chain, ::Val{:between}, site1::Site, site2::Site; direction::Symbol = :left)
     Λᵢ = select(tn, :between, site1, site2)

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -228,8 +228,8 @@ function Base.rand(rng::Random.AbstractRNG, sampler::ChainSampler, ::Type{Open},
     Chain(Operator(), Open(), arrays)
 end
 
-@valsplit 2 Tenet.contract(tn::Chain, query::Symbol, site1::Site, site2::Site; direction::Symbol = :left) =
-    Tenet.contract!(copy(tn), Val(query), site1, site2; direction = direction)
+Tenet.contract(tn::Chain, query::Symbol, args...; kwargs...) = contract!(copy(tn), Val(query), args...; kwargs...)
+@valsplit 2 Tenet.contract!(tn::Chain, query::Symbol, args...; kwargs...) = error("Query ':$query' not defined")
 
 function Tenet.contract!(tn::Chain, ::Val{:between}, site1::Site, site2::Site; direction::Symbol = :left)
     Λᵢ = select(tn, :between, site1, site2)

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -345,7 +345,6 @@ function isleftcanonical(qtn::Chain, site; atol::Real = 1e-12)
 
     # TODO is replace(conj(A)...) copying too much?
     contracted = contract(tensor, replace(conj(tensor), right_ind => :new_ind_name))
-    println("contracted: $contracted")
     n = size(tensor, right_ind)
     identity_matrix = Matrix(I, n, n)
 
@@ -364,7 +363,6 @@ function isrightcanonical(qtn::Chain, site; atol::Real = 1e-12)
 
     #TODO is replace(conj(A)...) copying too much?
     contracted = contract(tensor, replace(conj(tensor), left_ind => :new_ind_name))
-    println("contracted: $contracted")
     n = size(tensor, left_ind)
     identity_matrix = Matrix(I, n, n)
 

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -234,8 +234,6 @@ function Tenet.contract!(tn::Chain, ::Val{:between}, site1::Site, site2::Site; d
     Λᵢ = select(tn, :between, site1, site2)
     Λᵢ === nothing && return tn
 
-    Λᵢ = pop!(TensorNetwork(tn), Λᵢ)
-
     if direction === :right
         Γᵢ₊₁ = select(tn, :tensor, site2)
         replace!(TensorNetwork(tn), Γᵢ₊₁ => contract(Γᵢ₊₁, Λᵢ, dims = ()))
@@ -245,6 +243,8 @@ function Tenet.contract!(tn::Chain, ::Val{:between}, site1::Site, site2::Site; d
     else
         throw(ArgumentError("Unknown direction=:$direction"))
     end
+
+    delete!(TensorNetwork(tn), Λᵢ)
 
     return tn
 end

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -111,6 +111,11 @@
             qtn = rand(Chain, Open, State; n = 5, p = 2, χ = 20)
             canonized = canonize(qtn)
 
+            @test_throws ArgumentError contract(canonized, :between, Site(1), Site(2); direction = :dummy)
+            @test_throws ArgumentError contract!(canonized, :between, Site(1), Site(2); direction = :dummy)
+
+            canonized = canonize(qtn)
+
             for i in 1:4
                 contract_some = contract(canonized, :between, Site(i), Site(i + 1))
                 Bᵢ = select(contract_some, :tensor, Site(i))

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -120,8 +120,6 @@
                 Bᵢ = select(contract_some, :tensor, Site(i))
 
                 @test isapprox(contract(TensorNetwork(contract_some)), contract(TensorNetwork(qtn)))
-
-                @test length(tensors(canonized)) == length(tensors(contract_some)) + 1 # We removed one singular value vector
                 @test_throws ArgumentError select(contract_some, :between, Site(i), Site(i + 1))
 
                 @test isrightcanonical(contract_some, Site(i))

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -109,10 +109,9 @@
 
         @testset "contract" begin
             qtn = rand(Chain, Open, State; n = 5, p = 2, χ = 20)
-            canonized = canonize(qtn)
-
-            @test_throws ArgumentError contract(canonized, :between, Site(1), Site(2); direction = :dummy)
-            @test_throws ArgumentError contract!(canonized, :between, Site(1), Site(2); direction = :dummy)
+            let canonized = canonize(qtn)
+                @test_throws ArgumentError contract!(canonized, :between, Site(1), Site(2); direction = :dummy)
+            end
 
             canonized = canonize(qtn)
 

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -187,28 +187,34 @@
             Λ = [select(canonized, :between, Site(i), Site(i + 1)) for i in 1:4]
             @test map(λ -> sum(abs2, λ), Λ) ≈ ones(length(Λ)) * norm(canonized)^2
 
-            for i in 1:4
+            for i in 1:5
                 canonized = canonize(qtn)
 
                 if i == 1
                     @test isleftcanonical(canonized, Site(i))
+                elseif i == 5 # in the limits of the chain, we get the norm of the state
+                    contract!(canonized, :between, Site(i - 1), Site(i); direction = :right)
+                    tensor = select(canonized, :tensor, Site(i))
+                    replace!(TensorNetwork(canonized), tensor => tensor / norm(canonized))
+                    @test isleftcanonical(canonized, Site(i))
                 else
-                    Γᵢ = select(canonized, :tensor, Site(i))
-                    Λᵢ = pop!(TensorNetwork(canonized), select(canonized, :between, Site(i - 1), Site(i)))
-                    replace!(TensorNetwork(canonized), Γᵢ => contract(Λᵢ, Γᵢ; dims = ()))
+                    contract!(canonized, :between, Site(i - 1), Site(i); direction = :right)
                     @test isleftcanonical(canonized, Site(i))
                 end
             end
 
-            for i in 2:5
+            for i in 1:5
                 canonized = canonize(qtn)
 
-                if i == 5
+                if i == 1 # in the limits of the chain, we get the norm of the state
+                    contract!(canonized, :between, Site(i), Site(i + 1); direction = :left)
+                    tensor = select(canonized, :tensor, Site(i))
+                    replace!(TensorNetwork(canonized), tensor => tensor / norm(canonized))
+                    @test isrightcanonical(canonized, Site(i))
+                elseif i == 5
                     @test isrightcanonical(canonized, Site(i))
                 else
-                    Γᵢ = select(canonized, :tensor, Site(i))
-                    Λᵢ₊₁ = pop!(TensorNetwork(canonized), select(canonized, :between, Site(i), Site(i + 1)))
-                    replace!(TensorNetwork(canonized), Γᵢ => contract(Γᵢ, Λᵢ₊₁; dims = ()))
+                    contract!(canonized, :between, Site(i), Site(i + 1); direction = :left)
                     @test isrightcanonical(canonized, Site(i))
                 end
             end

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -115,6 +115,8 @@
                 contract_some = contract(canonized, :between, Site(i), Site(i + 1))
                 Bᵢ = select(contract_some, :tensor, Site(i))
 
+                @test isapprox(contract(TensorNetwork(contract_some)), contract(TensorNetwork(qtn)))
+
                 @test length(tensors(canonized)) == length(tensors(contract_some)) + 1 # We removed one singular value vector
                 @test_throws ArgumentError select(contract_some, :between, Site(i), Site(i + 1))
 


### PR DESCRIPTION
### Summary
This PR enhances the `Tenet.contract` function, enabling it to `contract` the singular values within a bond between two `Site`s. It introduces an optional `direction` argument, allowing users to specify whether the singular values should be contracted onto the `:left` or the `:right` tensor.

Additionally, we have added tests for this new functionality, and refactored the existing tests for the `canonize!` function, resulting in more compact and efficient test code.

### Example:
Let's exemplify the function:
```julia
julia> qtn = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2, 2), rand(2, 2, 2), rand(2, 2)])
MPS (inputs=0, outputs=5)

julia> canonized = canonize(qtn)
MPS (inputs=0, outputs=5)

julia> length(tensors(canonized))
9

julia> contract!(canonized, :between, Site(1), Site(2))
MPS (inputs=0, outputs=5)

julia> length(tensors(canonized)) # We removed one singular value vector
8

julia> select(canonized, :between, Site(1), Site(2))
ERROR: ArgumentError: collection must be non-empty
Stacktrace: ...

julia> @test isapprox(contract(TensorNetwork(canonized)), contract(TensorNetwork(qtn)))
Test Passed

```