### PR TITLE
Implement `evolve` of an `MPS` with an `MPO`

### DIFF
--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -652,6 +652,53 @@ function unpack_2sitewf!(ψ::Chain, bond, left_inds, right_inds, virtualind)
     return ψ
 end
 
+"""
+    evolve!(ψ::Chain, mpo::Chain)
+
+Applies a Matrix Product Operator (MPO) `mpo` to the [`Chain`](@ref).
+"""
+function evolve(ψ::Chain, mpo::Chain)
+    updated_tensors = Tensor[]
+    Λ = Tensor[]
+    L = nsites(ψ)
+
+    for i in 1:L
+        t = contract(select(ψ, :tensor, Site(i)), select(mpo, :tensor, Site(i)); dims=(select(ψ, :index, Site(i)),))
+        physicalind = select(mpo, :index, Site(i))
+
+        # Fuse the two right legs of t into one
+        if i == 1
+            wanted_inds = (physicalind, rightindex(ψ, Site(i)), rightindex(mpo, Site(i)))
+            new_inds = (physicalind, rightindex(ψ, Site(i)))
+        elseif i < L
+            wanted_inds = (physicalind, leftindex(ψ, Site(i)), leftindex(mpo, Site(i)), rightindex(ψ, Site(i)), rightindex(mpo, Site(i)))
+            new_inds = (physicalind, leftindex(ψ, Site(i)), rightindex(ψ, Site(i)))
+        else
+            wanted_inds = (physicalind, leftindex(ψ, Site(i)), leftindex(mpo, Site(i)))
+            new_inds = (physicalind, leftindex(ψ, Site(i)))
+        end
+
+        perm = Tenet.__find_index_permutation(wanted_inds, inds(t))
+        t = PermutedDimsArray(parent(t), perm)
+
+        t = Tensor(reshape(t, tuple(size(t, 1), [size(t, k) * size(t, k + 1) for k in 2:2:length(wanted_inds)]...)), new_inds)
+        push!(updated_tensors, t)
+
+        if i < L
+            Λᵢ = select(ψ, :between, Site(i), Site(i + 1))
+            Λᵢ = Tensor(diag(kron(Matrix(LinearAlgebra.I, d, d), diagm(parent(Λᵢ)))), inds(Λᵢ))
+            push!(Λ, Λᵢ)
+        end
+    end
+
+    ψ_ev = MPS(updated_tensors)
+    for i in 1:L-1
+        push!(TensorNetwork(ψ_ev), Tensor(parent(Λ[i]), (rightindex(ψ_ev, Site(i)),)))
+    end
+
+    return ψ_ev
+end
+
 function expect(ψ::Chain, observables)
     # contract observable with TN
     ϕ = copy(ψ)

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -685,6 +685,7 @@ function evolve(ψ::Chain, mpo::Chain)
         push!(updated_tensors, t)
 
         if i < L
+            d = size(TensorNetwork(mpo), rightindex(mpo, Site(i)))
             Λᵢ = select(ψ, :between, Site(i), Site(i + 1))
             Λᵢ = Tensor(diag(kron(Matrix(LinearAlgebra.I, d, d), diagm(parent(Λᵢ)))), inds(Λᵢ))
             push!(Λ, Λᵢ)


### PR DESCRIPTION
### Summary
This PR introduces the `evolve` function, which evolves a Matrix Product State (`MPS`) using a Matrix Product Operator (`MPO`). The idea from @starsfordummies is that we contract the tensors of each corresponding site, and we then create the new `λ` with a `kron` product with the old `λ` (which come from the `MPS`) and the identity (comes from the `MPO`). Right now, this function only works for `mps` in the canonical form.

### Example
Here we show how can we use this function:
```julia
julia> using Qrochet

julia> ψ = rand(Chain, Open, State; n=8, χ=10); canonize!(ψ)
MPS (inputs=0, outputs=8)

julia> mpo = rand(Chain, Open, Operator; n=8, χ=10)

MPO (inputs=8, outputs=8)

julia> Qrochet.@reindex! inputs(mpo) => outputs(ψ)

MPS (inputs=0, outputs=8)

julia> ψ = Qrochet.evolve(ψ, mpo)
MPS (inputs=0, outputs=8)

julia> size.(tensors(ψ))
15-element Vector{Tuple{Int64, Vararg{Int64}}}:
 (2, 8)
 (2, 8, 40)
 (2, 40, 80)
 (2, 80, 100)
 (2, 100, 80)
 (2, 80, 40)
 (2, 40, 8)
 (2, 8)
 (8,)
 (40,)
 (80,)
 (100,)
 (80,)
 (40,)
 (8,)
```