### PR TITLE
Add `order` keyword argument in `Chain` constructor functions

### DIFF
--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -30,12 +30,12 @@ function Chain(tn::TensorNetwork, sites, args...; kwargs...)
     Chain(Quantum(tn, sites), args...; kwargs...)
 end
 
-defaultorder(::State) = (:o, :l, :r)
-defaultorder(::Operator) = (:o, :i, :l, :r)
+defaultorder(::Type{Chain}, ::State) = (:o, :l, :r)
+defaultorder(::Type{Chain}, ::Operator) = (:o, :i, :l, :r)
 
-function Chain(::State, boundary::Periodic, arrays::Vector{<:AbstractArray}; order = defaultorder(State()))
+function Chain(::State, boundary::Periodic, arrays::Vector{<:AbstractArray}; order = defaultorder(Chain, State()))
     @assert all(==(3) ∘ ndims, arrays) "All arrays must have 3 dimensions"
-    issetequal(order, defaultorder(State())) ||
+    issetequal(order, defaultorder(Chain, State())) ||
         throw(ArgumentError("order must be a permutation of $(String.(defaultorder(State())))"))
 
     n = length(arrays)
@@ -65,7 +65,7 @@ function Chain(::State, boundary::Periodic, arrays::Vector{<:AbstractArray}; ord
     Chain(Quantum(TensorNetwork(_tensors), sitemap), boundary)
 end
 
-function Chain(::State, boundary::Open, arrays::Vector{<:AbstractArray}; order = defaultorder(State()))
+function Chain(::State, boundary::Open, arrays::Vector{<:AbstractArray}; order = defaultorder(Chain, State()))
     @assert ndims(arrays[1]) == 2 "First array must have 2 dimensions"
     @assert all(==(3) ∘ ndims, arrays[2:end-1]) "All arrays must have 3 dimensions"
     @assert ndims(arrays[end]) == 2 "Last array must have 2 dimensions"
@@ -107,7 +107,7 @@ function Chain(::State, boundary::Open, arrays::Vector{<:AbstractArray}; order =
     Chain(Quantum(TensorNetwork(_tensors), sitemap), boundary)
 end
 
-function Chain(::Operator, boundary::Periodic, arrays::Vector{<:AbstractArray}; order = defaultorder(Operator()))
+function Chain(::Operator, boundary::Periodic, arrays::Vector{<:AbstractArray}; order = defaultorder(Chain, Operator()))
     @assert all(==(4) ∘ ndims, arrays) "All arrays must have 4 dimensions"
     issetequal(order, defaultorder(Operator())) ||
         throw(ArgumentError("order must be a permutation of $(String.(defaultorder(Operator())))"))
@@ -142,7 +142,7 @@ function Chain(::Operator, boundary::Periodic, arrays::Vector{<:AbstractArray}; 
     Chain(Quantum(TensorNetwork(_tensors), sitemap), boundary)
 end
 
-function Chain(::Operator, boundary::Open, arrays::Vector{<:AbstractArray}; order = defaultorder(Operator()))
+function Chain(::Operator, boundary::Open, arrays::Vector{<:AbstractArray}; order = defaultorder(Chain, Operator()))
     @assert ndims(arrays[1]) == 3 "First array must have 3 dimensions"
     @assert all(==(4) ∘ ndims, arrays[2:end-1]) "All arrays must have 4 dimensions"
     @assert ndims(arrays[end]) == 3 "Last array must have 3 dimensions"

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -35,7 +35,8 @@ defaultorder(::Operator) = (:o, :i, :l, :r)
 
 function Chain(::State, boundary::Periodic, arrays::Vector{<:AbstractArray}; order = defaultorder(State()))
     @assert all(==(3) ∘ ndims, arrays) "All arrays must have 3 dimensions"
-    issetequal(order, defaultorder(State())) || throw(ArgumentError("order must be a permutation of $(String.(defaultorder(State())))"))
+    issetequal(order, defaultorder(State())) ||
+        throw(ArgumentError("order must be a permutation of $(String.(defaultorder(State())))"))
 
     n = length(arrays)
     symbols = [nextindex() for _ in 1:2n]
@@ -45,9 +46,9 @@ function Chain(::State, boundary::Periodic, arrays::Vector{<:AbstractArray}; ord
             if dir == :o
                 symbols[i]
             elseif dir == :r
-                symbols[n + mod1(i, n)]
+                symbols[n+mod1(i, n)]
             elseif dir == :l
-                symbols[n + mod1(i - 1, n)]
+                symbols[n+mod1(i - 1, n)]
             else
                 throw(ArgumentError("Invalid direction: $dir"))
             end
@@ -68,7 +69,8 @@ function Chain(::State, boundary::Open, arrays::Vector{<:AbstractArray}; order =
     @assert ndims(arrays[1]) == 2 "First array must have 2 dimensions"
     @assert all(==(3) ∘ ndims, arrays[2:end-1]) "All arrays must have 3 dimensions"
     @assert ndims(arrays[end]) == 2 "Last array must have 2 dimensions"
-    issetequal(order, defaultorder(State())) || throw(ArgumentError("order must be a permutation of $(String.(defaultorder(State())))"))
+    issetequal(order, defaultorder(State())) ||
+        throw(ArgumentError("order must be a permutation of $(String.(defaultorder(State())))"))
 
     n = length(arrays)
     symbols = [nextindex() for _ in 1:2n]
@@ -84,9 +86,9 @@ function Chain(::State, boundary::Open, arrays::Vector{<:AbstractArray}; order =
             if dir == :o
                 symbols[i]
             elseif dir == :r
-                symbols[n + mod1(i, n)]
+                symbols[n+mod1(i, n)]
             elseif dir == :l
-                symbols[n + mod1(i - 1, n)]
+                symbols[n+mod1(i - 1, n)]
             else
                 throw(ArgumentError("Invalid direction: $dir"))
             end
@@ -107,7 +109,8 @@ end
 
 function Chain(::Operator, boundary::Periodic, arrays::Vector{<:AbstractArray}; order = defaultorder(Operator()))
     @assert all(==(4) ∘ ndims, arrays) "All arrays must have 4 dimensions"
-    issetequal(order, defaultorder(Operator())) || throw(ArgumentError("order must be a permutation of $(String.(defaultorder(Operator())))"))
+    issetequal(order, defaultorder(Operator())) ||
+        throw(ArgumentError("order must be a permutation of $(String.(defaultorder(Operator())))"))
 
     n = length(arrays)
     symbols = [nextindex() for _ in 1:3n]
@@ -117,11 +120,11 @@ function Chain(::Operator, boundary::Periodic, arrays::Vector{<:AbstractArray}; 
             if dir == :o
                 symbols[i]
             elseif dir == :i
-                symbols[i + n]
+                symbols[i+n]
             elseif dir == :l
-                symbols[2n + mod1(i - 1, n)]
+                symbols[2n+mod1(i - 1, n)]
             elseif dir == :r
-                symbols[2n + mod1(i, n)]
+                symbols[2n+mod1(i, n)]
             else
                 throw(ArgumentError("Invalid direction: $dir"))
             end
@@ -134,7 +137,7 @@ function Chain(::Operator, boundary::Periodic, arrays::Vector{<:AbstractArray}; 
     end
 
     sitemap = Dict(Site(i) => symbols[i] for i in 1:n)
-    merge!(sitemap, Dict(Site(i; dual = true) => symbols[i + n] for i in 1:n))
+    merge!(sitemap, Dict(Site(i; dual = true) => symbols[i+n] for i in 1:n))
 
     Chain(Quantum(TensorNetwork(_tensors), sitemap), boundary)
 end
@@ -143,7 +146,8 @@ function Chain(::Operator, boundary::Open, arrays::Vector{<:AbstractArray}; orde
     @assert ndims(arrays[1]) == 3 "First array must have 3 dimensions"
     @assert all(==(4) ∘ ndims, arrays[2:end-1]) "All arrays must have 4 dimensions"
     @assert ndims(arrays[end]) == 3 "Last array must have 3 dimensions"
-    issetequal(order, defaultorder(Operator())) || throw(ArgumentError("order must be a permutation of $(String.(defaultorder(Operator())))"))
+    issetequal(order, defaultorder(Operator())) ||
+        throw(ArgumentError("order must be a permutation of $(String.(defaultorder(Operator())))"))
 
     n = length(arrays)
     symbols = [nextindex() for _ in 1:3n-1]
@@ -159,11 +163,11 @@ function Chain(::Operator, boundary::Open, arrays::Vector{<:AbstractArray}; orde
             if dir == :o
                 symbols[i]
             elseif dir == :i
-                symbols[i + n]
+                symbols[i+n]
             elseif dir == :l
-                symbols[2n + mod1(i - 1, n)]
+                symbols[2n+mod1(i - 1, n)]
             elseif dir == :r
-                symbols[2n + mod1(i, n)]
+                symbols[2n+mod1(i, n)]
             else
                 throw(ArgumentError("Invalid direction: $dir"))
             end
@@ -178,7 +182,7 @@ function Chain(::Operator, boundary::Open, arrays::Vector{<:AbstractArray}; orde
     end
 
     sitemap = Dict(Site(i) => symbols[i] for i in 1:n)
-    merge!(sitemap, Dict(Site(i; dual = true) => symbols[i + n] for i in 1:n))
+    merge!(sitemap, Dict(Site(i; dual = true) => symbols[i+n] for i in 1:n))
 
     Chain(Quantum(TensorNetwork(_tensors), sitemap), boundary)
 end

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -77,7 +77,13 @@ function Chain(::State, boundary::Open, arrays::Vector{<:AbstractArray}; order =
         elseif i == n
             _order = filter(x -> x != :r, order)
         else
-            _order = order
+         local order = if i == 1
+             filter(x -> x != :l, order)
+         elseif i == n
+             filter(x -> x != :r, order)
+         else
+             order
+         end
         end
 
         inds = map(_order) do dir

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -71,7 +71,7 @@ function Chain(::State, boundary::Open, arrays::Vector{<:AbstractArray}; order =
     issetequal(order, defaultorder(State())) || throw(ArgumentError("order must be a permutation of $(String.(defaultorder(State())))"))
 
     n = length(arrays)
-    symbols = [nextindex() for _ in 1:2n-1]
+    symbols = [nextindex() for _ in 1:2n]
 
     function get_index(directions, i, is_first, is_last)
         if is_first

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -41,8 +41,8 @@ function Chain(::State, boundary::Periodic, arrays::Vector{<:AbstractArray}; ord
     n = length(arrays)
     symbols = [nextindex() for _ in 1:2n]
 
-    function get_index(directions, i)
-        map(directions) do dir
+    _tensors = map(enumerate(arrays)) do (i, array)
+        inds = map(order) do dir
             if dir == :o
                 symbols[i]
             elseif dir == :r
@@ -53,10 +53,6 @@ function Chain(::State, boundary::Periodic, arrays::Vector{<:AbstractArray}; ord
                 throw(ArgumentError("Invalid direction: $dir"))
             end
         end
-    end
-
-    _tensors = map(enumerate(arrays)) do (i, array)
-        inds = get_index(order, i)
         Tensor(array, inds)
     end
 
@@ -69,20 +65,22 @@ function Chain(::State, boundary::Open, arrays::Vector{<:AbstractArray}; order =
     @assert ndims(arrays[1]) == 2 "First array must have 2 dimensions"
     @assert all(==(3) ∘ ndims, arrays[2:end-1]) "All arrays must have 3 dimensions"
     @assert ndims(arrays[end]) == 2 "Last array must have 2 dimensions"
-    issetequal(order, defaultorder(State())) ||
-        throw(ArgumentError("order must be a permutation of $(String.(defaultorder(State())))"))
+    issetequal(order, defaultorder(Chain, State())) ||
+        throw(ArgumentError("order must be a permutation of $(String.(defaultorder(Chain, State())))"))
 
     n = length(arrays)
     symbols = [nextindex() for _ in 1:2n]
 
-    function get_index(directions, i, is_first, is_last)
-        if is_first
-            directions = filter(x -> x != :l, directions)
-        elseif is_last
-            directions = filter(x -> x != :r, directions)
+    _tensors = map(enumerate(arrays)) do (i, array)
+        if i == 1
+            _order = filter(x -> x != :l, order)
+        elseif i == n
+            _order = filter(x -> x != :r, order)
+        else
+            _order = order
         end
 
-        map(directions) do dir
+        inds = map(_order) do dir
             if dir == :o
                 symbols[i]
             elseif dir == :r
@@ -93,12 +91,6 @@ function Chain(::State, boundary::Open, arrays::Vector{<:AbstractArray}; order =
                 throw(ArgumentError("Invalid direction: $dir"))
             end
         end
-    end
-
-    _tensors = map(enumerate(arrays)) do (i, array)
-        is_first = (i == 1)
-        is_last = (i == n)
-        inds = get_index(order, i, is_first, is_last)
         Tensor(array, inds)
     end
 
@@ -109,14 +101,14 @@ end
 
 function Chain(::Operator, boundary::Periodic, arrays::Vector{<:AbstractArray}; order = defaultorder(Chain, Operator()))
     @assert all(==(4) ∘ ndims, arrays) "All arrays must have 4 dimensions"
-    issetequal(order, defaultorder(Operator())) ||
-        throw(ArgumentError("order must be a permutation of $(String.(defaultorder(Operator())))"))
+    issetequal(order, defaultorder(Chain, Operator())) ||
+        throw(ArgumentError("order must be a permutation of $(String.(defaultorder(Chain, Operator())))"))
 
     n = length(arrays)
     symbols = [nextindex() for _ in 1:3n]
 
-    function get_index(directions, i)
-        map(directions) do dir
+    _tensors = map(enumerate(arrays)) do (i, array)
+        inds = map(order) do dir
             if dir == :o
                 symbols[i]
             elseif dir == :i
@@ -129,10 +121,6 @@ function Chain(::Operator, boundary::Periodic, arrays::Vector{<:AbstractArray}; 
                 throw(ArgumentError("Invalid direction: $dir"))
             end
         end
-    end
-
-    _tensors = map(enumerate(arrays)) do (i, array)
-        inds = get_index(order, i)
         Tensor(array, inds)
     end
 
@@ -146,20 +134,22 @@ function Chain(::Operator, boundary::Open, arrays::Vector{<:AbstractArray}; orde
     @assert ndims(arrays[1]) == 3 "First array must have 3 dimensions"
     @assert all(==(4) ∘ ndims, arrays[2:end-1]) "All arrays must have 4 dimensions"
     @assert ndims(arrays[end]) == 3 "Last array must have 3 dimensions"
-    issetequal(order, defaultorder(Operator())) ||
-        throw(ArgumentError("order must be a permutation of $(String.(defaultorder(Operator())))"))
+    issetequal(order, defaultorder(Chain, Operator())) ||
+        throw(ArgumentError("order must be a permutation of $(String.(defaultorder(Chain, Operator())))"))
 
     n = length(arrays)
     symbols = [nextindex() for _ in 1:3n-1]
 
-    function get_index(directions, i, is_first, is_last)
-        if is_first
-            directions = filter(x -> x != :l, directions)
-        elseif is_last
-            directions = filter(x -> x != :r, directions)
+    _tensors = map(enumerate(arrays)) do (i, array)
+        if i == 1
+            _order = filter(x -> x != :l, order)
+        elseif i == n
+            _order = filter(x -> x != :r, order)
+        else
+            _order = order
         end
 
-        map(directions) do dir
+        inds = map(_order) do dir
             if dir == :o
                 symbols[i]
             elseif dir == :i
@@ -172,12 +162,6 @@ function Chain(::Operator, boundary::Open, arrays::Vector{<:AbstractArray}; orde
                 throw(ArgumentError("Invalid direction: $dir"))
             end
         end
-    end
-
-    _tensors = map(enumerate(arrays)) do (i, array)
-        is_first = (i == 1)
-        is_last = (i == n)
-        inds = get_index(order, i, is_first, is_last)
         Tensor(array, inds)
     end
 

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -72,18 +72,12 @@ function Chain(::State, boundary::Open, arrays::Vector{<:AbstractArray}; order =
     symbols = [nextindex() for _ in 1:2n]
 
     _tensors = map(enumerate(arrays)) do (i, array)
-        if i == 1
-            _order = filter(x -> x != :l, order)
+        _order = if i == 1
+            filter(x -> x != :l, order)
         elseif i == n
-            _order = filter(x -> x != :r, order)
+            filter(x -> x != :r, order)
         else
-         local order = if i == 1
-             filter(x -> x != :l, order)
-         elseif i == n
-             filter(x -> x != :r, order)
-         else
-             order
-         end
+            order
         end
 
         inds = map(_order) do dir
@@ -147,12 +141,12 @@ function Chain(::Operator, boundary::Open, arrays::Vector{<:AbstractArray}; orde
     symbols = [nextindex() for _ in 1:3n-1]
 
     _tensors = map(enumerate(arrays)) do (i, array)
-        if i == 1
-            _order = filter(x -> x != :l, order)
+        _order = if i == 1
+            filter(x -> x != :l, order)
         elseif i == n
-            _order = filter(x -> x != :r, order)
+            filter(x -> x != :r, order)
         else
-            _order = order
+            order
         end
 
         inds = map(_order) do dir

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -44,9 +44,9 @@ function Chain(::State, boundary::Periodic, arrays::Vector{<:AbstractArray}; ord
         map(directions) do dir
             if dir == :o
                 symbols[i]
-            elseif dir == :l
-                symbols[n + mod1(i, n)]
             elseif dir == :r
+                symbols[n + mod1(i, n)]
+            elseif dir == :l
                 symbols[n + mod1(i - 1, n)]
             else
                 throw(ArgumentError("Invalid direction: $dir"))
@@ -83,9 +83,9 @@ function Chain(::State, boundary::Open, arrays::Vector{<:AbstractArray}; order =
         map(directions) do dir
             if dir == :o
                 symbols[i]
-            elseif dir == :l
-                symbols[n + mod1(i, n)]
             elseif dir == :r
+                symbols[n + mod1(i, n)]
+            elseif dir == :l
                 symbols[n + mod1(i - 1, n)]
             else
                 throw(ArgumentError("Invalid direction: $dir"))

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -67,9 +67,9 @@
             @test size(tensors(qtn; at = Site(2))) == (6, 2, 3, 4)
             @test size(tensors(qtn; at = Site(3))) == (1, 2, 6, 4)
 
-            @test leftindex(qtn, Site(1)) == rightindex(qtn, Site(3))
-            @test leftindex(qtn, Site(2)) == rightindex(qtn, Site(1))
-            @test leftindex(qtn, Site(3)) == rightindex(qtn, Site(2))
+            @test leftindex(qtn, Site(1)) == rightindex(qtn, Site(3)) !== nothing
+            @test leftindex(qtn, Site(2)) == rightindex(qtn, Site(1)) !== nothing
+            @test leftindex(qtn, Site(3)) == rightindex(qtn, Site(2)) !== nothing
 
             for i in 1:length(arrays)
                 @test size(TensorNetwork(qtn), inds(qtn; at = Site(i))) == 2
@@ -107,8 +107,8 @@
             @test size(tensors(qtn; at = Site(3))) == (2, 3)
 
             @test leftindex(qtn, Site(1)) == rightindex(qtn, Site(3)) === nothing
-            @test leftindex(qtn, Site(2)) == rightindex(qtn, Site(1))
-            @test leftindex(qtn, Site(3)) == rightindex(qtn, Site(2))
+            @test leftindex(qtn, Site(2)) == rightindex(qtn, Site(1)) !== nothing
+            @test leftindex(qtn, Site(3)) == rightindex(qtn, Site(2)) !== nothing
 
             for i in 1:nsites(qtn)
                 @test size(TensorNetwork(qtn), inds(qtn; at = Site(i))) == 2
@@ -131,8 +131,8 @@
             @test size(tensors(qtn; at = Site(3))) == (2, 4, 3)
 
             @test leftindex(qtn, Site(1)) == rightindex(qtn, Site(3)) === nothing
-            @test leftindex(qtn, Site(2)) == rightindex(qtn, Site(1))
-            @test leftindex(qtn, Site(3)) == rightindex(qtn, Site(2))
+            @test leftindex(qtn, Site(2)) == rightindex(qtn, Site(1)) !== nothing
+            @test leftindex(qtn, Site(3)) == rightindex(qtn, Site(2)) !== nothing
 
             for i in 1:length(arrays)
                 @test size(TensorNetwork(qtn), inds(qtn; at = Site(i))) == 2
@@ -147,8 +147,8 @@
             @test size(tensors(qtn; at = Site(3))) == (2, 3, 4)
 
             @test leftindex(qtn, Site(1)) == rightindex(qtn, Site(3)) === nothing
-            @test leftindex(qtn, Site(2)) == rightindex(qtn, Site(1))
-            @test leftindex(qtn, Site(3)) == rightindex(qtn, Site(2))
+            @test leftindex(qtn, Site(2)) == rightindex(qtn, Site(1)) !== nothing
+            @test leftindex(qtn, Site(3)) == rightindex(qtn, Site(2)) !== nothing
 
             for i in 1:length(arrays)
                 @test size(TensorNetwork(qtn), inds(qtn; at = Site(i))) == 2

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -99,12 +99,12 @@
             @test leftindex(qtn, Site(2)) == rightindex(qtn, Site(1))
             @test leftindex(qtn, Site(3)) == rightindex(qtn, Site(2))
 
-            arrays = [permutedims(arrays[1], (2, 1)), permutedims(arrays[2], (3, 1, 2)), permutedims(arrays[3], (2, 1))] # now we have (:l, :o, :r)
+            arrays = [permutedims(arrays[1], (2, 1)), permutedims(arrays[2], (3, 1, 2)), permutedims(arrays[3], (1, 2))] # now we have (:r, :o, :l)
             qtn = Chain(State(), Open(), arrays, order=[:r, :o, :l])
 
             @test size(tensors(qtn; at = Site(1))) == (1, 2)
             @test size(tensors(qtn; at = Site(2))) == (3, 2, 1)
-            @test size(tensors(qtn; at = Site(3))) == (3, 2)
+            @test size(tensors(qtn; at = Site(3))) == (2, 3)
 
             @test leftindex(qtn, Site(1)) == rightindex(qtn, Site(3)) === nothing
             @test leftindex(qtn, Site(2)) == rightindex(qtn, Site(1))
@@ -139,12 +139,12 @@
                 @test size(TensorNetwork(qtn), inds(qtn; at = Site(i; dual=true))) == 4
             end
 
-            arrays = [permutedims(array, (3, 1, 2)), permutedims(array, (4, 1, 3, 2)), permutedims(array, (3, 1, 2))] # now we have (:r, :o, :l, :i)
+            arrays = [permutedims(arrays[1], (3, 1, 2)), permutedims(arrays[2], (4, 1, 3, 2)), permutedims(arrays[3], (1, 3, 2))] # now we have (:r, :o, :l, :i)
             qtn = Chain(Operator(), Open(), arrays, order=[:r, :o, :l, :i])
 
             @test size(tensors(qtn; at = Site(1))) == (1, 2, 4)
             @test size(tensors(qtn; at = Site(2))) == (3, 2, 1, 4)
-            @test size(tensors(qtn; at = Site(3))) == (3, 2, 4)
+            @test size(tensors(qtn; at = Site(3))) == (2, 3, 4)
 
             @test leftindex(qtn, Site(1)) == rightindex(qtn, Site(3)) === nothing
             @test leftindex(qtn, Site(2)) == rightindex(qtn, Site(1))

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -35,6 +35,7 @@
                 @test size(TensorNetwork(qtn), inds(qtn; at = Site(i))) == 2
             end
         end
+
         @testset "Operator" begin
             qtn = Chain(Operator(), Periodic(), [rand(2, 2, 4, 4) for _ in 1:3])
             @test socket(qtn) == Operator()

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -21,7 +21,7 @@
             @test leftindex(qtn, Site(3)) == rightindex(qtn, Site(2))
 
             arrays = [permutedims(array, (3, 1, 2)) for array in arrays] # now we have (:r, :o, :l)
-            qtn = Chain(State(), Periodic(), arrays, order=[:r, :o, :l])
+            qtn = Chain(State(), Periodic(), arrays, order = [:r, :o, :l])
 
             @test size(tensors(qtn; at = Site(1))) == (4, 2, 1)
             @test size(tensors(qtn; at = Site(2))) == (3, 2, 4)
@@ -57,11 +57,11 @@
 
             for i in 1:length(arrays)
                 @test size(TensorNetwork(qtn), inds(qtn; at = Site(i))) == 2
-                @test size(TensorNetwork(qtn), inds(qtn; at = Site(i; dual=true))) == 4
+                @test size(TensorNetwork(qtn), inds(qtn; at = Site(i; dual = true))) == 4
             end
 
             arrays = [permutedims(array, (4, 1, 3, 2)) for array in arrays] # now we have (:r, :o, :l, :i)
-            qtn = Chain(Operator(), Periodic(), arrays, order=[:r, :o, :l, :i])
+            qtn = Chain(Operator(), Periodic(), arrays, order = [:r, :o, :l, :i])
 
             @test size(tensors(qtn; at = Site(1))) == (3, 2, 1, 4)
             @test size(tensors(qtn; at = Site(2))) == (6, 2, 3, 4)
@@ -73,7 +73,7 @@
 
             for i in 1:length(arrays)
                 @test size(TensorNetwork(qtn), inds(qtn; at = Site(i))) == 2
-                @test size(TensorNetwork(qtn), inds(qtn; at = Site(i; dual=true))) == 4
+                @test size(TensorNetwork(qtn), inds(qtn; at = Site(i; dual = true))) == 4
             end
         end
     end
@@ -100,7 +100,7 @@
             @test leftindex(qtn, Site(3)) == rightindex(qtn, Site(2))
 
             arrays = [permutedims(arrays[1], (2, 1)), permutedims(arrays[2], (3, 1, 2)), permutedims(arrays[3], (1, 2))] # now we have (:r, :o, :l)
-            qtn = Chain(State(), Open(), arrays, order=[:r, :o, :l])
+            qtn = Chain(State(), Open(), arrays, order = [:r, :o, :l])
 
             @test size(tensors(qtn; at = Site(1))) == (1, 2)
             @test size(tensors(qtn; at = Site(2))) == (3, 2, 1)
@@ -136,11 +136,15 @@
 
             for i in 1:length(arrays)
                 @test size(TensorNetwork(qtn), inds(qtn; at = Site(i))) == 2
-                @test size(TensorNetwork(qtn), inds(qtn; at = Site(i; dual=true))) == 4
+                @test size(TensorNetwork(qtn), inds(qtn; at = Site(i; dual = true))) == 4
             end
 
-            arrays = [permutedims(arrays[1], (3, 1, 2)), permutedims(arrays[2], (4, 1, 3, 2)), permutedims(arrays[3], (1, 3, 2))] # now we have (:r, :o, :l, :i)
-            qtn = Chain(Operator(), Open(), arrays, order=[:r, :o, :l, :i])
+            arrays = [
+                permutedims(arrays[1], (3, 1, 2)),
+                permutedims(arrays[2], (4, 1, 3, 2)),
+                permutedims(arrays[3], (1, 3, 2)),
+            ] # now we have (:r, :o, :l, :i)
+            qtn = Chain(Operator(), Open(), arrays, order = [:r, :o, :l, :i])
 
             @test size(tensors(qtn; at = Site(1))) == (1, 2, 4)
             @test size(tensors(qtn; at = Site(2))) == (3, 2, 1, 4)
@@ -152,7 +156,7 @@
 
             for i in 1:length(arrays)
                 @test size(TensorNetwork(qtn), inds(qtn; at = Site(i))) == 2
-                @test size(TensorNetwork(qtn), inds(qtn; at = Site(i; dual=true))) == 4
+                @test size(TensorNetwork(qtn), inds(qtn; at = Site(i; dual = true))) == 4
             end
         end
     end


### PR DESCRIPTION
This PR resolves #46 by adding an `order` keyword argument that allows arbitrary order of the dimensions of the tensors, as long as all those arrays are in the same order.

### Example
```julia
julia> using Qrochet

julia> mps = Chain(State(), Open(), [rand(3, 2), rand(3, 5, 2), rand(5, 2)]; order=(:l, :r, :o))
MPS (inputs=0, outputs=3)

julia> inds.(tensors(mps))
3-element Vector{Vector{Symbol}}:
 [:D, :A]
 [:D, :E, :B]
 [:E, :C]
```