### PR TITLE
Fix `mixed_canonize` function

### DIFF
--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -514,6 +514,9 @@ function mixed_canonize!(::Open, tn::Chain, center::Site) # TODO: center could b
         canonize_site!(tn, Site(i); direction = :left, method = :qr)
     end
 
+    # center SVD sweep to get singular values
+    canonize_site!(tn, center; direction = :left, method = :svd)
+
     return tn
 end
 

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -500,7 +500,7 @@ mixed_canonize!(tn::Chain, args...; kwargs...) = mixed_canonize!(boundary(tn), t
     mixed_canonize!(boundary::Boundary, tn::Chain, center::Site)
 
 Transform a `Chain` tensor network into the mixed-canonical form, that is,
-for i < center the tensors are left-canonical and for i > center the tensors are right-canonical,
+for i < center the tensors are left-canonical and for i >= center the tensors are right-canonical,
 and in the center there is a matrix with singular values.
 """
 function mixed_canonize!(::Open, tn::Chain, center::Site) # TODO: center could be a range of sites

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -528,7 +528,7 @@ to mixed-canonized form with the given center site.
 """
 function LinearAlgebra.normalize!(tn::Chain, root::Site; p::Real = 2)
     mixed_canonize!(tn, root)
-    normalize!(tensors(Quantum(tn); at = root), p)
+    normalize!(tensors(tn; between = (Site(id(root)-1), root)), p)
     return tn
 end
 

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -528,7 +528,7 @@ to mixed-canonized form with the given center site.
 """
 function LinearAlgebra.normalize!(tn::Chain, root::Site; p::Real = 2)
     mixed_canonize!(tn, root)
-    normalize!(tensors(tn; between = (Site(id(root)-1), root)), p)
+    normalize!(tensors(tn; between = (Site(id(root) - 1), root)), p)
     return tn
 end
 

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -359,9 +359,11 @@
             qtn = Chain(State(), Open(), [rand(4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4)])
             canonized = mixed_canonize(qtn, Site(3))
 
+            @test length(tensors(canonized)) == length(tensors(qtn)) + 1
+
             @test isleftcanonical(canonized, Site(1))
             @test isleftcanonical(canonized, Site(2))
-            @test !isleftcanonical(canonized, Site(3)) && !isrightcanonical(canonized, Site(3))
+            @test isrightcanonical(canonized, Site(3))
             @test isrightcanonical(canonized, Site(4))
             @test isrightcanonical(canonized, Site(5))
 


### PR DESCRIPTION
This PR fixes the `mixed_canonize` function by adding a missing `svd` step in the `center` of the `Chain`. This step is crucial to ensure that we have the singular values in the `center` and all the tensors are in the proper canonical form.

Since the function `normalize!` depended on the previous implementation of `mixed_canonize`, we add a small fix for this function too. 