### PR TITLE
Fix `leftsite` and `rightsite` for `adjoint` `Chain`s 

### DIFF
--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -183,19 +183,22 @@ function Base.convert(::Type{Chain}, qtn::Product)
 end
 
 leftsite(tn::Chain, site::Site) = leftsite(boundary(tn), tn, site)
-leftsite(::Open, tn::Chain, site::Site) = id(site) ∈ range(2, nlanes(tn)) ? Site(id(site) - 1) : nothing
-leftsite(::Periodic, tn::Chain, site::Site) = Site(mod1(id(site) - 1, nlanes(tn)))
+leftsite(::Open, tn::Chain, site::Site) =
+    id(site) ∈ range(2, nlanes(tn)) ? Site(id(site) - 1; dual = isdual(site)) : nothing
+leftsite(::Periodic, tn::Chain, site::Site) = Site(mod1(id(site) - 1, nlanes(tn)); dual = isdual(site))
 
 rightsite(tn::Chain, site::Site) = rightsite(boundary(tn), tn, site)
-rightsite(::Open, tn::Chain, site::Site) = id(site) ∈ range(1, nlanes(tn) - 1) ? Site(id(site) + 1) : nothing
-rightsite(::Periodic, tn::Chain, site::Site) = Site(mod1(id(site) + 1, nlanes(tn)))
+rightsite(::Open, tn::Chain, site::Site) =
+    id(site) ∈ range(1, nlanes(tn) - 1) ? Site(id(site) + 1; dual = isdual(site)) : nothing
+rightsite(::Periodic, tn::Chain, site::Site) = Site(mod1(id(site) + 1, nlanes(tn)); dual = isdual(site))
 
 leftindex(tn::Chain, site::Site) = leftindex(boundary(tn), tn, site)
 leftindex(::Open, tn::Chain, site::Site) = site == site"1" ? nothing : leftindex(Periodic(), tn, site)
 leftindex(::Periodic, tn::Chain, site::Site) = inds(tn; bond = (site, leftsite(tn, site)))
 
 rightindex(tn::Chain, site::Site) = rightindex(boundary(tn), tn, site)
-rightindex(::Open, tn::Chain, site::Site) = site == Site(nlanes(tn)) ? nothing : rightindex(Periodic(), tn, site)
+rightindex(::Open, tn::Chain, site::Site) =
+    site == Site(nlanes(tn); dual = isdual(site)) ? nothing : rightindex(Periodic(), tn, site)
 rightindex(::Periodic, tn::Chain, site::Site) = inds(tn; bond = (site, rightsite(tn, site)))
 
 Base.adjoint(chain::Chain) = Chain(adjoint(Quantum(chain)), boundary(chain))

--- a/test/Ansatz/Chain_test.jl
+++ b/test/Ansatz/Chain_test.jl
@@ -380,5 +380,18 @@
         isapprox(norm(qtn), 1.0)
     end
 
+    @testset "adjoint" begin
+        qtn = rand(Chain, Open, State; n = 5, p = 2, χ = 10)
+        adjoint_qtn = adjoint(qtn)
+
+        for i in 1:nsites(qtn)
+            i < nsites(qtn) &&
+                @test rightindex(adjoint_qtn, Site(i; dual = true)) == Symbol(String(rightindex(qtn, Site(i))) * "'")
+            i > 1 && @test leftindex(adjoint_qtn, Site(i; dual = true)) == Symbol(String(leftindex(qtn, Site(i))) * "'")
+        end
+
+        @test isapprox(contract(TensorNetwork(qtn)), contract(TensorNetwork(adjoint_qtn)))
+    end
+
     # TODO test `evolve!` methods
 end


### PR DESCRIPTION
Previously, doing `leftsite` or `rightsite` for a `Chain` that is adjoint, returned a `Site` that does not have `dual=true`. This caused the functions `leftindex` and `rightindex` to not work for adjointed ` Chain`s.

#### Example (code before the PR):
```julia
julia> using Qrochet

julia> mps = rand(Chain, Open, State; n=8, χ=10)
MPS (inputs=0, outputs=8)

julia> Qrochet.rightsite(mps', Site(2; dual=true))
3

julia> rightindex(mps', Site(2; dual=true))
ERROR: AssertionError: Site 3 not found
Stacktrace: ...

julia> rightindex(mps', Site(2))
ERROR: AssertionError: Site 2 not found
Stacktrace: ...
```

This PR addresses this issue by fixing the `leftsite` or `rightsite` functions. Additionally, we added the `testset` for the `adjoint` for `Chain`s.

#### Example (fixed code):
```julia
julia> using Qrochet

julia> mps = rand(Chain, Open, State; n=8, χ=10)
MPS (inputs=0, outputs=8)

julia> Qrochet.rightsite(mps', Site(2; dual=true))
3'

julia> rightindex(mps', Site(2; dual=true))
Symbol("Z'")
```